### PR TITLE
Add transaction naming function to MassTransitDiagnosticsSubscriber

### DIFF
--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticInitializer.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticInitializer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using MassTransit;
 
 namespace Elastic.Apm.Messaging.MassTransit
 {

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticInitializer.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticInitializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using MassTransit;
 
 namespace Elastic.Apm.Messaging.MassTransit
 {
@@ -7,10 +8,12 @@ namespace Elastic.Apm.Messaging.MassTransit
     {
         private readonly IApmAgent _apmAgent;
         private IDisposable? _sourceSubscription;
+        private readonly Func<ReceiveContext, string> _transactionNameFunc;
 
-        internal MassTransitDiagnosticInitializer(IApmAgent apmAgent)
+        internal MassTransitDiagnosticInitializer(IApmAgent apmAgent, Func<ReceiveContext, string> transactionNameFunc)
         {
             _apmAgent = apmAgent;
+            _transactionNameFunc = transactionNameFunc;
         }
 
         public void Dispose() => _sourceSubscription?.Dispose();
@@ -28,7 +31,7 @@ namespace Elastic.Apm.Messaging.MassTransit
             if (string.Equals(value.Name, Constants.DiagnosticListener.Name,
                 StringComparison.InvariantCultureIgnoreCase))
             {
-                _sourceSubscription = value.Subscribe(new MassTransitDiagnosticListener(_apmAgent));
+                _sourceSubscription = value.Subscribe(new MassTransitDiagnosticListener(_apmAgent, _transactionNameFunc));
             }
         }
     }

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticInitializer.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticInitializer.cs
@@ -8,12 +8,12 @@ namespace Elastic.Apm.Messaging.MassTransit
     {
         private readonly IApmAgent _apmAgent;
         private IDisposable? _sourceSubscription;
-        private readonly Func<ReceiveContext, string> _transactionNameFunc;
+        private readonly MassTransitDiagnosticOptions _options;
 
-        internal MassTransitDiagnosticInitializer(IApmAgent apmAgent, Func<ReceiveContext, string> transactionNameFunc)
+        internal MassTransitDiagnosticInitializer(IApmAgent apmAgent, MassTransitDiagnosticOptions options)
         {
             _apmAgent = apmAgent;
-            _transactionNameFunc = transactionNameFunc;
+            _options = options;
         }
 
         public void Dispose() => _sourceSubscription?.Dispose();
@@ -31,7 +31,7 @@ namespace Elastic.Apm.Messaging.MassTransit
             if (string.Equals(value.Name, Constants.DiagnosticListener.Name,
                 StringComparison.InvariantCultureIgnoreCase))
             {
-                _sourceSubscription = value.Subscribe(new MassTransitDiagnosticListener(_apmAgent, _transactionNameFunc));
+                _sourceSubscription = value.Subscribe(new MassTransitDiagnosticListener(_apmAgent, _options));
             }
         }
     }

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticListener.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticListener.cs
@@ -13,16 +13,16 @@ namespace Elastic.Apm.Messaging.MassTransit
     {
         private readonly IApmAgent _apmAgent;
         private readonly IApmLogger _logger;
-        private readonly Func<ReceiveContext, string> _transactionNameFunc;
+        private readonly MassTransitDiagnosticOptions _options;
 
         private readonly ConcurrentDictionary<ActivitySpanId, IExecutionSegment> _activities = 
             new ConcurrentDictionary<ActivitySpanId, IExecutionSegment>();
 
-        internal MassTransitDiagnosticListener(IApmAgent apmAgent, Func<ReceiveContext, string> transactionNameFunc)
+        internal MassTransitDiagnosticListener(IApmAgent apmAgent, MassTransitDiagnosticOptions options)
         {
             _apmAgent = apmAgent;
+            _options = options;
             _logger = apmAgent.Logger;
-            _transactionNameFunc = transactionNameFunc;
         }
 
         public void OnNext(KeyValuePair<string, object?> value)
@@ -93,7 +93,7 @@ namespace Elastic.Apm.Messaging.MassTransit
                 if (context is ReceiveContext receiveContext)
                 {
                     DistributedTracingData? tracingData = receiveContext.GetTracingData();
-                    var transactionName = _transactionNameFunc(receiveContext);
+                    var transactionName = _options.GetTransactionName(receiveContext);
 
                     ITransaction transaction = _apmAgent.Tracer.StartTransaction(
                         transactionName,

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticOptions.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticOptions.cs
@@ -1,0 +1,29 @@
+using System;
+using MassTransit;
+
+namespace Elastic.Apm.Messaging.MassTransit
+{
+    public class MassTransitDiagnosticOptions
+    {
+        private readonly Func<ReceiveContext, string> _defaultTransactionName =
+            context => $"Receive {context.InputAddress.AbsolutePath}";
+
+        internal MassTransitDiagnosticOptions()
+        {
+            TransactionName = _defaultTransactionName;
+        }
+
+        internal string GetTransactionName(ReceiveContext context)
+        {
+            var transactionName = TransactionName(context);
+            if (string.IsNullOrEmpty(transactionName))
+            {
+                transactionName = _defaultTransactionName(context);
+            }
+
+            return transactionName;
+        }
+
+        public Func<ReceiveContext, string> TransactionName { get; set; }
+    }
+}

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticsSubscriber.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using Elastic.Apm.DiagnosticSource;
-using MassTransit;
 
 namespace Elastic.Apm.Messaging.MassTransit
 {

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticsSubscriber.cs
@@ -10,15 +10,12 @@ namespace Elastic.Apm.Messaging.MassTransit
     /// </summary>
     public class MassTransitDiagnosticsSubscriber : IDiagnosticsSubscriber
     {
-        private readonly Func<ReceiveContext, string> _transactionNameFunc;
+        private MassTransitDiagnosticOptions _options;
 
-        public MassTransitDiagnosticsSubscriber()
-            : this(ctx => $"Receive {ctx.InputAddress.AbsolutePath}")
-        { }
-
-        public MassTransitDiagnosticsSubscriber(Func<ReceiveContext, string> transactionNameFunc)
+        public MassTransitDiagnosticsSubscriber(Action<MassTransitDiagnosticOptions>? configure = default)
         {
-            _transactionNameFunc = transactionNameFunc;
+            _options = new MassTransitDiagnosticOptions();
+            configure?.Invoke(_options);
         }
 
         /// <inheritdoc cref="IDiagnosticsSubscriber"/>
@@ -31,7 +28,7 @@ namespace Elastic.Apm.Messaging.MassTransit
                 return compositeDisposable;
             }
 
-            var initializer = new MassTransitDiagnosticInitializer(components, _transactionNameFunc);
+            var initializer = new MassTransitDiagnosticInitializer(components, _options);
             compositeDisposable.Add(initializer);
             compositeDisposable.Add(DiagnosticListener.AllListeners.Subscribe(initializer));
 


### PR DESCRIPTION
Add a transaction naming function to the constructor of MassTransitDiagnosticsSubscriber and pass it along to the diagnostics listener.
This makes it possible to have different naming schemes of the transaction in APM. As we are using RabbitMQ as our message broker in the system I am currently working with, I can now add RabbitMQ specific naming in my system.  Example:


    public class MassTransitRabbitMqDiagnosticsSubscriber : MassTransitDiagnosticsSubscriber
    {
        public MassTransitRabbitMqDiagnosticsSubscriber()
            : base(TransactionName)
        {
        }

        private static string TransactionName(ReceiveContext ctx) =>
            ctx is RabbitMqReceiveContext rabbitCtx
                ? $"Receive {rabbitCtx.Exchange}"
                : $"Receive {ctx.InputAddress.AbsolutePath}";
    }


Also added a default constructor that uses the same naming as before the change, so this should be a non-breaking change.

