### PR TITLE
Make message receive a root transaction

### DIFF
--- a/src/Elastic.Apm.Messaging.MassTransit/Constants.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/Constants.cs
@@ -3,6 +3,7 @@ namespace Elastic.Apm.Messaging.MassTransit
     internal struct Constants
     {
         internal const string TraceHeaderName = "Elastic.Apm";
+        internal const string MessageSourceHeaderName = "Elastic.Apm.MessageSource";
 
         internal struct DiagnosticListener
         {

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticListener.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticListener.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using Elastic.Apm.Api;
 using Elastic.Apm.Logging;
 using MassTransit;
-using MassTransit.Transports.InMemory;
 
 namespace Elastic.Apm.Messaging.MassTransit
 {
@@ -84,7 +83,7 @@ namespace Elastic.Apm.Messaging.MassTransit
 
                     span.Context.Message = new Message
                     {
-                        Queue = new Queue { Name = sendContext.DestinationAddress.GetQueueOrExchangeName() }
+                        Queue = new Queue { Name = sendContext.GetDestinationAbsoluteName() }
                     };
 
                     sendContext.SetTracingData(span);

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticOptions.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticOptions.cs
@@ -9,7 +9,7 @@ namespace Elastic.Apm.Messaging.MassTransit
             context => context.DestinationAddress.AbsolutePath;
 
         private readonly Func<ReceiveContext, string> _defaultReceiveLabel =
-            context => context.InputAddress.AbsolutePath;
+            context => $"on {context.InputAddress.AbsolutePath} from {context.GetMessageSource()}";
 
         internal MassTransitDiagnosticOptions()
         {
@@ -17,7 +17,7 @@ namespace Elastic.Apm.Messaging.MassTransit
             ReceiveLabel = _defaultReceiveLabel;
         }
 
-        internal string GetSendLabel(SendContext context) =>    
+        internal string GetSendLabel(SendContext context) =>
             GetLabel(context, SendLabel, _defaultSendLabel);
 
         internal string GetReceiveLabel(ReceiveContext context) =>
@@ -49,5 +49,13 @@ namespace Elastic.Apm.Messaging.MassTransit
         /// If the return value is empty or null, it will be replace with the default label.
         /// </summary>
         public Func<ReceiveContext, string> ReceiveLabel { get; set; }
+
+        /// <summary>
+        /// True if the receive transaction should has as a parent the send span and
+        /// false if the receive transaction is a root transaction.
+        /// Default: false.
+        /// </summary>
+        public bool InlineReceiveTransaction { get; set; } = false;
+
     }
 }

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticOptions.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticOptions.cs
@@ -56,6 +56,5 @@ namespace Elastic.Apm.Messaging.MassTransit
         /// Default: false.
         /// </summary>
         public bool InlineReceiveTransaction { get; set; } = false;
-
     }
 }

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitExtensions.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitExtensions.cs
@@ -18,7 +18,6 @@ namespace Elastic.Apm.Messaging.MassTransit
             context.Headers.Set(
                 Constants.TraceHeaderName,
                 tracingData);
-
             context.Headers.Set(
                 Constants.MessageSourceHeaderName,
                 context.DestinationAddress.AbsolutePath);

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitExtensions.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Elastic.Apm.Api;
 using MassTransit;
 
@@ -5,16 +6,39 @@ namespace Elastic.Apm.Messaging.MassTransit
 {
     internal static class MassTransitExtensions
     {
+        private static readonly Dictionary<string, string> SchemeToSubType = new()
+        {
+            { "sb", "azureservicebus" }
+        };
+
         internal static void SetTracingData(this SendContext context, ISpan span)
         {
             var tracingData = span.OutgoingDistributedTracingData.SerializeToString();
-            context.Headers.Set(Constants.TraceHeaderName, tracingData);
+            context.Headers.Set(
+                Constants.TraceHeaderName,
+                tracingData);
+
+            context.Headers.Set(
+                Constants.MessageSourceHeaderName,
+                context.DestinationAddress.AbsolutePath);
         }
 
         internal static DistributedTracingData? GetTracingData(this ReceiveContext context)
         {
             var tracingData = context.TransportHeaders.Get<string>(Constants.TraceHeaderName);
             return DistributedTracingData.TryDeserializeFromString(tracingData);
+        }
+
+        internal static string GetMessageSource(this ReceiveContext context)
+        {
+            return context.TransportHeaders.Get<string>(Constants.MessageSourceHeaderName);
+        }
+
+        internal static string GetSpanSubType(this SendContext context)
+        {
+            var scheme = context.DestinationAddress.Scheme;
+
+            return SchemeToSubType.TryGetValue(scheme, out var value) ? value : scheme;
         }
     }
 }

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitExtensions.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Elastic.Apm.Api;
 using MassTransit;
@@ -39,6 +40,13 @@ namespace Elastic.Apm.Messaging.MassTransit
             var scheme = context.DestinationAddress.Scheme;
 
             return SchemeToSubType.TryGetValue(scheme, out var value) ? value : scheme;
+        }
+
+        internal static string GetDestinationAbsoluteName(this SendContext context)
+        {
+            return context.DestinationAddress.AbsolutePath
+                .AsSpan(1, context.DestinationAddress.AbsolutePath.Length - 1)
+                .ToString();
         }
     }
 }


### PR DESCRIPTION
- add more send context
- make receive a root transaction by default
- and change receive default name

The old behavior can be achieved through options:
```csharp
new MassTransitDiagnosticsSubscriber(o =>
{
    o.InlineReceiveTransaction = true;
    o.ReceiveLabel = context => context.InputAddress.AbsolutePath;
})
```