### PR TITLE
MassTransit refine send and receive activities

### DIFF
--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticOptions.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitDiagnosticOptions.cs
@@ -9,7 +9,13 @@ namespace Elastic.Apm.Messaging.MassTransit
             context => context.DestinationAddress.AbsolutePath;
 
         private readonly Func<ReceiveContext, string> _defaultReceiveLabel =
-            context => $"on {context.InputAddress.AbsolutePath} from {context.GetMessageSource()}";
+            context =>
+            {
+                var messageSource = context.GetMessageSource();
+                return string.IsNullOrEmpty(messageSource)
+                    ? $"on {context.InputAddress.AbsolutePath}"
+                    : $"on {context.InputAddress.AbsolutePath} from {messageSource}";
+            };
 
         internal MassTransitDiagnosticOptions()
         {

--- a/src/Elastic.Apm.Messaging.MassTransit/MassTransitExtensions.cs
+++ b/src/Elastic.Apm.Messaging.MassTransit/MassTransitExtensions.cs
@@ -41,10 +41,24 @@ namespace Elastic.Apm.Messaging.MassTransit
             return SchemeToSubType.TryGetValue(scheme, out var value) ? value : scheme;
         }
 
+        internal static string GetSpanSubType(this ReceiveContext context)
+        {
+            var scheme = context.InputAddress.Scheme;
+
+            return SchemeToSubType.TryGetValue(scheme, out var value) ? value : scheme;
+        }
+
         internal static string GetDestinationAbsoluteName(this SendContext context)
         {
             return context.DestinationAddress.AbsolutePath
                 .AsSpan(1, context.DestinationAddress.AbsolutePath.Length - 1)
+                .ToString();
+        }
+
+        internal static string GetInputAbsoluteName(this ReceiveContext context)
+        {
+            return context.InputAddress.AbsolutePath
+                .AsSpan(1, context.InputAddress.AbsolutePath.Length - 1)
                 .ToString();
         }
     }


### PR DESCRIPTION
- create transaction when send if is the case (e.g. background worker)
- create span if is a transaction, in that way we can crate a backend dependency on the receiver