### PR TITLE
Update to ElasticApm 1.18.0 and MassTransit 7.3.1

### DIFF
--- a/src/Dependencies.props
+++ b/src/Dependencies.props
@@ -1,9 +1,9 @@
 <Project>
 
   <PropertyGroup>
-    <ElasticApmVersion>1.13.0</ElasticApmVersion>
+    <ElasticApmVersion>1.18.0</ElasticApmVersion>
     <HotChocolateVersion>12.5.0</HotChocolateVersion>
-    <MassTransitVersion>7.1.0</MassTransitVersion>
+    <MassTransitVersion>7.3.1</MassTransitVersion>
     <SystemDiagnosticSourceVersion>4.7.0</SystemDiagnosticSourceVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Updating to ElasticApm 1.18.0 and MassTransit 7.3.1

We are using Elastic.Apm.Messaging.MassTransit package. When we updated to ElasticApm 1.18.0 and MassTransit 7.3.1 in our other projects we got some strange reference errors in runtime. Updating Elastic.Apm.Messaging.MassTransit to also reference the latest version of ElasticApm solved our problems.